### PR TITLE
refactor: 材積計算をTreeVolumeに切り出す

### DIFF
--- a/app/controllers/calculator_controller.rb
+++ b/app/controllers/calculator_controller.rb
@@ -15,7 +15,7 @@ class CalculatorController < ApplicationController
     height = params[:height].to_f
 
     # Calculate the volume (example formula)
-    @volume = 0.5 * Math::PI * (dbh / 100)**2 * height
+    @volume = TreeVolume.calculate(dbh: dbh, height: height)
 
     render :index
   end

--- a/app/models/tree_volume.rb
+++ b/app/models/tree_volume.rb
@@ -1,0 +1,6 @@
+class TreeVolume
+  def self.calculate(dbh:, height:)
+    0.5 * Math::PI * (dbh / 100.0) ** 2 * height
+  end
+end
+

--- a/spec/models/tree_volume_spec.rb
+++ b/spec/models/tree_volume_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe TreeVolume do
+  describe ".calculate" do
+    it "直径と高さから材積を計算できる" do
+      volume = described_class.calculate(dbh: 30, height: 4)
+
+      expected_volume = 0.5 * Math::PI * (30 / 100.0) ** 2 * 4
+
+      expect(volume).to eq(expected_volume)
+    end
+  end
+end


### PR DESCRIPTION
## 変更内容

* 材積計算のロジックをControllerから切り出し、`TreeVolume` クラスに移動
* `TreeVolume.calculate` で直径・高さから材積を計算できるように変更
* RSpecで材積計算の正常系を追加
* 既存の計算式と同じ結果になることを確認
* Local環境で既存の材積計算結果に影響がないことを確認

## テスト

* `bundle exec rspec`
* 1 example, 0 failures

close #26 