### PR TITLE
test: 地積計算のシステムスペックを追加

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,6 +63,16 @@ RSpec.configure do |config|
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
-  # arbitrary gems may also be filtered via:
-  # config.filter_gems_from_backtrace("gem name")
 end
+Capybara.register_driver :selenium_firefox do |app|
+  options = Selenium::WebDriver::Firefox::Options.new
+  options.add_argument("-headless")
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :firefox,
+    options: options
+  )
+end
+
+Capybara.javascript_driver = :selenium_firefox

--- a/spec/system/area_calculator_spec.rb
+++ b/spec/system/area_calculator_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+RSpec.describe "地積計算", type: :system do
+  before do
+    driven_by :selenium_firefox
+  end
+  describe "三角形1つの場合" do
+    it "正しい面積が表示される" do
+      visit root_path
+
+      fill_in "辺 A (m)", with: 3
+      fill_in "辺 B (m)", with: 4
+      fill_in "辺 C (m)", with: 5
+
+      click_button "面積を計算する"
+
+      expect(page).to have_content("6.0")
+      expect(page).to have_content("0.0006")
+    end
+  end
+  describe "三角形複数の場合" do
+    it "正しい面積が表示される" do
+      visit root_path
+
+      within all(".triangle").first do
+        fill_in "辺 A (m)", with: 3
+        fill_in "辺 B (m)", with: 4
+        fill_in "辺 C (m)", with: 5
+      end
+
+      click_button "三角形を追加"
+
+       expect(page).to have_css(".triangle", count: 2)
+
+        within all(".triangle").last do
+          fill_in "辺 A (m)", with: 3
+          fill_in "辺 B (m)", with: 4
+          fill_in "辺 C (m)", with: 5
+        end
+
+        click_button "面積を計算する"
+
+        expect(page).to have_content("12.0")
+        expect(page).to have_content("0.0012")
+    end
+  end
+end


### PR DESCRIPTION
## 変更内容

* 地積計算のSystem Specを追加
* 三角形1つの場合の面積計算をテスト
* 複数の三角形を追加した場合の合算結果をテスト
* m²およびhaへの換算結果をテスト
* Firefoxを使用したSystem Specの実行環境を追加
* 既存の地積計算結果に影響がないことを確認

## テスト

* `bundle exec rspec`
* 4 examples, 0 failures

## 補足

地積計算はJavaScript側で計算しているため、Model SpecではなくSystem Specで入力から画面表示までを確認しています。