### PR TITLE
test: 計算結果の境界値テストを追加

### DIFF
--- a/spec/models/tree_volume_spec.rb
+++ b/spec/models/tree_volume_spec.rb
@@ -9,5 +9,23 @@ RSpec.describe TreeVolume do
 
       expect(volume).to eq(expected_volume)
     end
+
+    it "計算可能な小さい数字(0.001㎥付近)" do
+      volume = described_class.calculate(dbh: 2.52, height: 1)
+
+      expect(volume).to be_within(0.0001).of(0.001)
+    end
+
+    it "0㎥付近" do
+      volume = described_class.calculate(dbh: 0, height: 1)
+
+      expect(volume).to eq(0)
+    end
+
+    it "大きい数字(39,269,908.17 m³付近)" do
+      volume = described_class.calculate(dbh: 10_000, height: 10_000)
+
+      expect(volume).to be_finite
+    end
   end
 end

--- a/spec/system/area_calculator_spec.rb
+++ b/spec/system/area_calculator_spec.rb
@@ -16,6 +16,45 @@ RSpec.describe "地積計算", type: :system do
       expect(page).to have_content("6.0")
       expect(page).to have_content("0.0006")
     end
+
+    it "辺が0の場合は0になる" do
+      visit root_path
+
+      fill_in "辺 A (m)", with: 0
+      fill_in "辺 B (m)", with: 0
+      fill_in "辺 C (m)", with: 0
+
+      click_button "面積を計算する"
+
+      expect(page).to have_content("0.0")
+      expect(page).to have_content("0.0")
+    end
+
+    it "小さい値でも計算できる" do
+      visit root_path
+
+      fill_in "辺 A (m)", with: 0.11
+      fill_in "辺 B (m)", with: 0.11
+      fill_in "辺 C (m)", with: 0.11
+
+      click_button "面積を計算する"
+
+      expect(page).to have_content("0.01")
+      expect(page).to have_content("0.0")
+    end
+
+    it "大きい数字でも計算できる" do
+      visit root_path
+
+      fill_in "辺 A (m)", with: 99999990
+      fill_in "辺 B (m)", with: 99999990
+      fill_in "辺 C (m)", with: 99999990
+
+      click_button "面積を計算する"
+
+      expect(page).to have_content("4330126152896832.5")
+      expect(page).to have_content("433012615289.6833")
+    end
   end
   describe "三角形複数の場合" do
     it "正しい面積が表示される" do


### PR DESCRIPTION
## 概要

計算結果の境界値テストを追加しました。

## 変更内容

* 材積計算の境界値テストを追加

  * 小さい値（0.001m³付近）
  * 0
  * 大きな値
* 地積計算の境界値テストを追加

  * 0
  * 小さい値
  * 大きな値
* 既存の複数三角形の計算テストを維持

## 確認結果

* 材積計算：4 examples, 0 failures
* 地積計算：5 examples, 0 failures

三角形として成立しない入力については、後続のバリデーション・エラー処理で対応予定です。
close #13 