### PR TITLE
ci: GitHub ActionsでRSpecを実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec rails db:prepare 
+      - run: bundle exec rspec
+


### PR DESCRIPTION
## 実装内容
- GitHub ActionsのWorkflowを作成
- PR作成・更新時にCIを実行
- `main`へのpush時にCIを実行
- Ruby環境をセットアップ
- `bundle install`を実行
- テスト用DBを準備
- RSpecを自動実行

## 確認内容
- `bundle exec rails db:prepare`：成功
- `bundle exec rspec`：28 examples, 0 failures
- GitHub ActionsでRSpecが実行されることを確認予定

## 備考
- 現在はSQLiteを使用しているため、CIでもSQLiteを使用
- PostgreSQLへの移行時にCIのDB設定も変更予定
- RuboCopは既存の違反箇所を修正後、CIへ追加予定